### PR TITLE
Default options to an empty object if it doesn't exist

### DIFF
--- a/stylish.js
+++ b/stylish.js
@@ -8,6 +8,8 @@ module.exports = {
 		var ret = '';
 		var headers = [];
 		var prevfile;
+		
+		options = options || {};
 
 		ret += table(
 			result.map(function (el, i) {


### PR DESCRIPTION
As I mentioned in issue #1

If options does not exist it causes an error upon testing if the verbose property is available on the options object. Therefor I default the options to an empty object.
