### PR TITLE
Changed the color blue from the warnings to be yellow

### DIFF
--- a/stylish.js
+++ b/stylish.js
@@ -28,7 +28,7 @@ module.exports = {
 				'',
 				chalk.gray('line ' + err.line),
 				chalk.gray('col ' + err.character),
-				isError ? chalk.red(err.reason) : (process.platform !== 'win32' ? chalk.blue(err.reason) : chalk.cyan(err.reason))
+				isError ? chalk.red(err.reason) : (process.platform !== 'win32' ? chalk.yellow(err.reason) : chalk.cyan(err.reason))
 			];
 
 			if (el.file !== prevfile) {


### PR DESCRIPTION
The warnings should be yellow, for me is more coherent with the warning symbol (also yellow).

And also my terminal don't deal very good with the color blue :smile: