### PR TITLE
using cyan instead of blue

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = {
 				'',
 				chalk.gray('line ' + err.line),
 				chalk.gray('col ' + err.character),
-				isError ? chalk.red(err.reason) : chalk.blue(err.reason)
+				isError ? chalk.red(err.reason) : chalk.cyan(err.reason)
 			];
 
 			if (el.file !== prevfile) {


### PR DESCRIPTION
On Windows, even the lighter blue is too difficult to read. Most libraries use cyan instead.