### PR TITLE
Added option to play system "beep" when errors are reported

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var table = require('text-table');
 var logSymbols = require('log-symbols');
 var stringLength = require('string-length');
 var plur = require('plur');
-var beep = require('beepbeep');
+var beeper = require('beeper');
 
 module.exports = {
 	toString: function () {
@@ -63,7 +63,7 @@ module.exports = {
 			ret += '  ' + logSymbols.warning + '  ' + warningCount + ' ' + plur('warning', total);
 
 			if (options.beep) {
-				beep();
+				beeper();
 			}
 		} else {
 			ret += '  ' + logSymbols.success + ' No problems';

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var table = require('text-table');
 var logSymbols = require('log-symbols');
 var stringLength = require('string-length');
 var plur = require('plur');
+var beep = require('beepbeep');
 
 module.exports = {
 	toString: function () {
@@ -60,6 +61,10 @@ module.exports = {
 			}
 
 			ret += '  ' + logSymbols.warning + '  ' + warningCount + ' ' + plur('warning', total);
+
+			if (options.beep) {
+				beep();
+			}
 		} else {
 			ret += '  ' + logSymbols.success + ' No problems';
 			ret = '\n' + ret.trim();

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "log-symbols": "^1.0.0",
     "plur": "^2.1.0",
     "string-length": "^1.0.0",
-    "text-table": "^0.2.0"
+    "text-table": "^0.2.0",
+    "beepbeep": "^1.2.0"
   },
   "devDependencies": {
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "plur": "^2.1.0",
     "string-length": "^1.0.0",
     "text-table": "^0.2.0",
-    "beepbeep": "^1.2.0"
+    "beeper": "^1.1.0"
   },
   "devDependencies": {
     "mocha": "*",

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,24 @@ grunt.loadNpmTasks('grunt-contrib-jshint');
 grunt.registerTask('default', ['jshint']);
 ```
 
+### Options
+
+#### options.beep
+
+Type: `boolean`
+Default: `false`
+
+If set to true, the system bell will sound whenever a warning or error is output.
+
+Gulp example:
+```js
+gulp.task('default', function () {
+	gulp.src(['file.js'])
+		.pipe(jshint('.jshintrc'))
+		.pipe(jshint.reporter('jshint-stylish', {beep: true}));
+});
+```
+
 
 ## License
 


### PR DESCRIPTION
I often times forget to check my console to see if there were errors/warnings printed when my files are linted (linting happens in real time as files are edited and changed). So, I added an option to play the system bell whenever errors or warnings are printed for a file. 

Simply pass {beep: true} in the options to enable the "beep".  

Note that it also adds a dependency on the "beepbeep" module.

This could be extended fairly easily to play a different number of beeps (based on how many errors were found in a file, for exampe), or only play beeps on errors and not warnings, etc.