### PR TITLE
Added new option errorsOnly.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,56 +20,68 @@ module.exports = {
 
 		options = options || {};
 
-		ret += table(result.map(function (el, i) {
-			var err = el.error;
-			// E: Error, W: Warning, I: Info
-			var isError = err.code && err.code[0] === 'E';
-
-			var line = [
-				'',
-				chalk.gray('line ' + err.line),
-				chalk.gray('col ' + err.character),
-				isError ? chalk.red(err.reason) : chalk.blue(err.reason)
-			];
-
-			if (el.file !== prevfile) {
-				headers[i] = el.file;
-			}
-
-			if (options.verbose) {
-				line.push(chalk.gray('(' + err.code + ')'));
-			}
-
-			if (isError) {
-				errorCount++;
-			} else {
-				warningCount++;
-			}
-
-			prevfile = el.file;
-
-			return line;
-		}), {
-			stringLength: stringLength
-		}).split('\n').map(function (el, i) {
-			return headers[i] ? '\n' + chalk.underline(headers[i]) + '\n' + el : el;
-		}).join('\n') + '\n\n';
-
-		if (total > 0) {
-			if (errorCount > 0) {
-				ret += '  ' + logSymbols.error + '  ' + errorCount + ' ' + plur('error', errorCount) + (warningCount > 0 ? '\n' : '');
-			}
-
-			ret += '  ' + logSymbols.warning + '  ' + warningCount + ' ' + plur('warning', total);
-
-			if (options.beep) {
-				beeper();
-			}
-		} else {
-			ret += '  ' + logSymbols.success + ' No problems';
-			ret = '\n' + ret.trim();
+		if (options.errorsOnly) {
+			var result = result.filter(function(el, i) {
+				var err = el.error;
+				// E: Error, W: Warning, I: Info
+				var isError = err.code && err.code[0] === 'E';
+				return ((options.errorsOnly && isError) || !options.errorsOnly);
+			});
 		}
 
-		console.log(ret + '\n');
+		if (result.length > 0) {
+			ret += table(result.map(function (el, i) {
+				var err = el.error;
+				// E: Error, W: Warning, I: Info
+				var isError = err.code && err.code[0] === 'E';
+
+				var line = [
+					'',
+					chalk.gray('line ' + err.line),
+					chalk.gray('col ' + err.character),
+					isError ? chalk.red(err.reason) : chalk.blue(err.reason)
+				];
+
+				if (el.file !== prevfile) {
+					headers[i] = el.file;
+				}
+
+				if (options.verbose) {
+					line.push(chalk.gray('(' + err.code + ')'));
+				}
+
+				if (isError) {
+					errorCount++;
+				} else {
+					warningCount++;
+				}
+
+				prevfile = el.file;
+
+				return line;
+			}), {
+				stringLength: stringLength
+			}).split('\n').map(function (el, i) {
+				return headers[i] ? '\n' + chalk.underline(headers[i]) + '\n' + el : el;
+			}).join('\n') + '\n\n';
+
+			if (total > 0) {
+				if (errorCount > 0) {
+					ret += '  ' + logSymbols.error + '  ' + errorCount + ' ' +
+					plur('error', errorCount) + (warningCount > 0 ? '\n' : '');
+				}
+
+				ret += '  ' + logSymbols.warning + '  ' + warningCount + ' ' + plur('warning', total);
+
+				if (options.beep) {
+					beeper();
+				}
+			} else {
+				ret += '  ' + logSymbols.success + ' No problems';
+				ret = '\n' + ret.trim();
+			}
+
+			console.log(ret + '\n');
+		}
 	}
 };

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,14 @@ Default: `false`
 
 The system bell will make a sound if there were any warnings or errors.
 
+#### errorsOnly
+
+Type: `boolean`<br>
+Default: `false`
+
+Prints only those jshint messages, marked as errors (E*)
+
+
 ###### Gulp example
 
 ```js


### PR DESCRIPTION
I have a big old project and I've just implemented jshint on it. At this point I have many, many warnings, which I am not able to fix immediately and it is really hard to find an error if there is one. So I've added this option, which helps you print only the errors, if you need to. 

The filtering is done only when errorsOnly is true, so there is no performance overhead in the standard case. In fact, I don't see any difference when I run it both ways.

Note about the diff:
I've preserved your tab-styled indentation, but the diff stil looks a little bit odd for me.
The only things I've changed are:

I've added the filtering block
```javascript
	if (options.errorsOnly) {
		var result = result.filter(function(el, i) {
			var err = el.error;
			// E: Error, W: Warning, I: Info
			var isError = err.code && err.code[0] === 'E';
			return ((options.errorsOnly && isError) || !options.errorsOnly);
		});
	}
```
And everything else is executed if result.length > 0. Inside the IF block I did nothing else but indentation.